### PR TITLE
Add sender whitelist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Light Phone team works on adding things like directions.
   * [h](#h) (help) shows available commands
   * [ping](#ping) tiny command for testing your gateway
   * [tip](#tip) calculates the tip at a restaurant
+* [Options](#options)
+  * [Sender whitelist](#sender-whitelist)
 * [Contributing a new command](#contributing-a-new-command)
   * [Creating a command](#creating-a-command)
   * [Registering the command](#registering-the-command)
@@ -193,6 +195,25 @@ Get the tip from your bill `amount` and tip `percentage`.
     -> tip 20 1234.56
 
     Tip: 246.91
+
+## Options
+
+### Sender whitelist
+
+If you don't want everyone to be able to use your app, you can add a sender whitelist.
+If you add such a whitelist, only the senders (i.e., phone numbers) in it will be able
+to receive information via the SMS commands.
+
+The whitelist is completely optional and you can edit or remove it at any time.
+
+*Extra cost:* None (possible savings)
+
+*Setup*:
+* `heroku config:set SENDER_WHITELIST=...`
+* You can add as many comma-separated phone numbers as you wish
+* The phone numbers can contain hyphens but *no spaces or parentheses*
+* Include `+`, the country code, and the area code in the phone number
+* Example: `heroku config:set SENDER_WHITELIST=+18001234567,+1-800-765-4321`
 
 ## Contributing a new command
 

--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,8 @@ class App < Sinatra::Base
         message.body(command.response_body)
       end
     else
-      logger.info "The sender is not whitelisted"
+      logger.info "The sender (#{params['From'].inspect}) is not "\
+        "in the whitelist (#{ENV['SENDER_WHITELIST'].inspect})"
     end
 
     twiml.to_s

--- a/lib/phone_whitelist.rb
+++ b/lib/phone_whitelist.rb
@@ -1,0 +1,16 @@
+# typed: strong
+# frozen_string_literal: true
+
+class PhoneWhitelist
+  extend T::Sig
+
+  sig { params(whitelist: T.nilable(String)).void }
+  def initialize(whitelist = nil)
+    @whitelist = T.let(whitelist ? whitelist.gsub('-', '').split(',') : nil, T.nilable(T::Array[String]))
+  end
+
+  sig { params(from: String).returns(T::Boolean) }
+  def valid_number?(from)
+    @whitelist.nil? || @whitelist.include?(from)
+  end
+end

--- a/spec/lib/phone_whitelist_spec.rb
+++ b/spec/lib/phone_whitelist_spec.rb
@@ -1,0 +1,75 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../lib/phone_whitelist'
+
+RSpec.describe PhoneWhitelist do
+  describe '#valid_number?' do
+    it 'validates a phone number in the absence of a whitelist' do
+      whitelist = PhoneWhitelist.new(nil)
+
+      expect(whitelist.valid_number?('+12061234567')).to eq(true)
+    end
+
+    it 'validates a phone number against a whitelist of one' do
+      whitelist = PhoneWhitelist.new('+12061234567')
+
+      expect(whitelist.valid_number?('+12061234567')).to eq(true)
+    end
+
+    it 'does not validate a phone number that is not included in the whitelist' do
+      whitelist = PhoneWhitelist.new('+12061234567 +18001234567')
+
+      expect(whitelist.valid_number?('+18881234567')).to eq(false)
+    end
+
+    it 'validates a phone number against comma-separated numbers' do
+      whitelist = PhoneWhitelist.new('+12061234567,+18001234567,+15207654321')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(true)
+    end
+
+    it 'does not validate a phone number against non-comma-separated numbers' do
+      whitelist = PhoneWhitelist.new('+12061234567 +18001234567')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(false)
+    end
+
+    it 'validates a phone number against hyphen-containing ones' do
+      whitelist = PhoneWhitelist.new('+1-800-123-4567')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(true)
+    end
+
+    it 'does not validate a number against space-containing ones' do
+      whitelist = PhoneWhitelist.new('+1 800 123 4567')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(false)
+    end
+
+    it 'does not validate a number against parenthesis-containing ones' do
+      whitelist = PhoneWhitelist.new('+1-(800)-123-4567')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(false)
+    end
+
+    it 'does not validate a number against ones missing the area code' do
+      whitelist = PhoneWhitelist.new('1234567')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(false)
+    end
+
+    it 'does not validate a number against ones missing the country code' do
+      whitelist = PhoneWhitelist.new('8001234567')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(false)
+    end
+
+    it 'does not validate a number against ones missing the + sign' do
+      whitelist = PhoneWhitelist.new('18001234567')
+
+      expect(whitelist.valid_number?('+18001234567')).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Added the option to whitelist senders' phone numbers. This is to allow app owners to prevent random people from using their app.

The sender whitelist is optional and set via a Heroku config var.

Also updated the README.