### PR TITLE
Add 'details' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Light Phone team works on adding things like directions.
 * [Setup](#setup)
 * [Cost](#cost)
 * [Supported Commands](#supported-commands)
+  * [details](#details) returns Google Maps place details
   * [directions](#directions) texts you Google Maps directions
   * [h](#h) (help) shows available commands
   * [ping](#ping) tiny command for testing your gateway
@@ -72,6 +73,49 @@ this service!
 ## Supported Commands
 
 Here are the currently supported commands. If you want to add more commands, see [Contributing a new command](#contributing-a-new-command).
+
+### details
+
+This command will text you the available info about a specific place listed on Google Maps.
+If there are more than one match, the command returns a list of the top 10 results instead.
+
+*NOTE:* this command does *not* factor in the location of your phone.
+
+*Syntax*: `details <place>`
+*Extra cost:* consult Google Maps API fees
+
+*Params:*
+* `place` - a description of the place, as precise as possible
+
+*Setup*:
+* [Get an API key for Google Maps](https://developers.google.com/maps/gmp-get-started)
+* `heroku config:set GOOGLE_MAPS_API_KEY=...`
+
+*Examples:*
+
+    -> details korean restaurant victoria bc
+
+    (1) NARU Korean Restaurant, Wharf Street, Victoria, BC, Canada
+    (2) Cera Korean Restaurant, Pandora Avenue, Victoria, BC, Canada
+    (3) Han Korean Restaurant, Johnson Street, Victoria, BC, Canada
+    (4) Sura Korean Restaurant, Douglas Street, Victoria, BC, Canada
+    (5) Sumi Korean Restaurant, Victoria Drive, Vancouver, BC, Canada
+
+    -> details naru victoria bc
+
+    NARU Korean Restaurant
+    1218 Wharf St, Victoria, BC V8W 1T8, Canada
+    Phone: (250) 590-5298
+    Rating: 4.5
+    Closed now
+    Hours:
+    * Monday: 11:30 AM - 4:00 PM, 5:00 - 9:30 PM
+    * Tuesday: 11:30 AM - 4:00 PM, 5:00 - 9:30 PM
+    * Wednesday: 11:30 AM - 4:00 PM, 5:00 - 9:30 PM
+    * Thursday: 11:30 AM - 4:00 PM, 5:00 - 9:30 PM
+    * Friday: 11:30 AM - 4:00 PM, 5:00 - 9:30 PM
+    * Saturday: 11:30 AM - 4:00 PM, 5:00 - 9:30 PM
+    * Sunday: Closed
 
 ### directions
 
@@ -315,4 +359,4 @@ Once the tunnel is up:
 
 Thanks to these folks for contributing:
 
-* @l33loo - added `tip` command and phone whitelisting!
+* @l33loo - added `details` and `tip` commands, and phone whitelisting!

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require_relative './commands/base'
+require_relative './commands/details'
 require_relative './commands/directions'
 require_relative './commands/help'
 require_relative './commands/ping'
@@ -13,6 +14,7 @@ module Commands
   sig { returns(T::Array[T.class_of(Commands::Base)]) }
   def self.all
     [
+      Commands::Details,
       Commands::Directions,
       Commands::Help,
       Commands::Ping,

--- a/lib/commands/details.rb
+++ b/lib/commands/details.rb
@@ -28,13 +28,13 @@ module Commands
     def response_body
       return api_key_missing unless api_key_exists?
 
-      return help if arg_text === ''
+      return help if arg_text.empty?
 
       begin
         places = Google::Maps.places(arg_text)
         place = Google::Maps.place(places.first.place_id)
       rescue StandardError => error
-        return "NO RESULTS FOR \"#{arg_text}\"" if error.message === 'Google did not return any results: ZERO_RESULTS'
+        return "NO RESULTS FOR \"#{arg_text}\"" if error.message == 'Google did not return any results: ZERO_RESULTS'
         return error.message
       rescue
         return 'THERE WAS AN ERROR'

--- a/lib/commands/details.rb
+++ b/lib/commands/details.rb
@@ -39,8 +39,15 @@ module Commands
         return error.message
       end
 
-      return "#{places.slice(0, 10).map.with_index { |e, i| "(#{i + 1}) #{e}" }.join(%Q{\n})}" if places.length > 1
+      return list_of_places(places) if places.length > 1
 
+      build_response(place)
+    end
+
+    private
+
+    sig { params(place: Google::Maps::PlaceDetails).returns(String) }
+    def build_response(place)
       place_name = place.name
       place_address = place.address
       data = place.data
@@ -54,10 +61,14 @@ module Commands
         "\nHours:\n* #{data.opening_hours.weekday_text.join(%Q{\n* })}"
         :
         ''
-      response = "#{place_name}\n#{place_address}#{data_phone}#{data_rating}"\
-        "#{data_price_level}#{data_permanently_closed}#{open_now}#{weekday_hours}"
 
-      response
+      "#{place_name}\n#{place_address}#{data_phone}#{data_rating}"\
+        "#{data_price_level}#{data_permanently_closed}#{open_now}#{weekday_hours}"
+    end
+
+    sig { params(places: T::Array[Google::Maps::Place]).returns(String) }
+    def list_of_places(places)
+      places.slice(0, 10).map.with_index { |place, index| "(#{index + 1}) #{place}" }.join(%Q{\n})
     end
   end
 end

--- a/lib/commands/details.rb
+++ b/lib/commands/details.rb
@@ -1,0 +1,64 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require_relative './google_maps_api'
+
+module Commands
+  class Details < GoogleMapsAPI
+    extend T::Sig
+
+    sig { override.returns(String) }
+    def self.name
+      'details'
+    end
+
+    sig { override.returns(String) }
+    def self.help
+      <<~HELP
+        details <place>: returns available info about a specific place listed on Google Maps.
+        If there are more than one match, the command returns a list of the top 10 results instead.
+
+        Examples:
+        details living computers museum, seattle wa
+        details korean restaurant victoria bc
+      HELP
+    end
+
+    sig { override.returns(String) }
+    def response_body
+      return api_key_missing unless api_key_exists?
+
+      return help if arg_text === ''
+
+      begin
+        places = Google::Maps.places(arg_text)
+        place = Google::Maps.place(places.first.place_id)
+      rescue StandardError => error
+        return "NO RESULTS FOR \"#{arg_text}\"" if error.message === 'Google did not return any results: ZERO_RESULTS'
+        return error.message
+      rescue
+        return 'THERE WAS AN ERROR'
+      end
+
+      return "#{places.slice(0, 10).map.with_index { |e, i| "(#{i + 1}) #{e}" }.join(%Q{\n})}" if places.length > 1
+
+      place_name = place.name
+      place_address = place.address
+      data = place.data
+      data_phone = data.formatted_phone_number ? "\nPhone: #{data.formatted_phone_number}" : ''
+      data_rating = data.rating ? "\nRating: #{data.rating}" : ''
+      data_price_level = data.price_level ? "\nPrice level (0\{free\}-4): #{data.price_level}" : ''
+      data_permanently_closed = data.permanently_closed ? 'PERMAMENTLY CLOSED' : ''
+      data_hours = data.opening_hours
+      open_now = defined?(data_hours.open_now) ? (data_hours.open_now ? "\nOpen now" : "\nClosed now") : ''
+      weekday_hours = defined?(data_hours.weekday_text) ?
+        "\nHours:\n* #{data.opening_hours.weekday_text.join(%Q{\n* })}"
+        :
+        ''
+      response = "#{place_name}\n#{place_address}#{data_phone}#{data_rating}"\
+        "#{data_price_level}#{data_permanently_closed}#{open_now}#{weekday_hours}"
+
+      response
+    end
+  end
+end

--- a/lib/commands/details.rb
+++ b/lib/commands/details.rb
@@ -33,11 +33,10 @@ module Commands
       begin
         places = Google::Maps.places(arg_text)
         place = Google::Maps.place(places.first.place_id)
-      rescue StandardError => error
-        return "NO RESULTS FOR \"#{arg_text}\"" if error.message == 'Google did not return any results: ZERO_RESULTS'
+      rescue Google::Maps::ZeroResultsException
+        return "NO RESULTS FOR \"#{arg_text}\""
+      rescue => error
         return error.message
-      rescue
-        return 'THERE WAS AN ERROR'
       end
 
       return "#{places.slice(0, 10).map.with_index { |e, i| "(#{i + 1}) #{e}" }.join(%Q{\n})}" if places.length > 1

--- a/lib/commands/directions.rb
+++ b/lib/commands/directions.rb
@@ -1,16 +1,10 @@
-# typed: false
+# typed: ignore
 # frozen_string_literal: true
 
-require_relative './base'
-require 'google-maps'
-
-Google::Maps.configure do |config|
-  config.authentication_mode = Google::Maps::Configuration::API_KEY
-  config.api_key = ENV['GOOGLE_MAPS_API_KEY']
-end
+require_relative './google_maps_api'
 
 module Commands
-  class Directions < Base
+  class Directions < GoogleMapsAPI
     extend T::Sig
 
     class Mode < T::Enum
@@ -64,21 +58,6 @@ module Commands
       )
 
       RoutePresenter.new(route, mode: query.mode).to_text
-    end
-
-    private
-
-    def api_key_missing
-      <<~MSG
-        Your Google Maps API key is missing.
-        Create a new key at: https://developers.google.com/maps/gmp-get-started
-
-        Once you get a key, set it to ENV['GOOGLE_MAPS_API_KEY'] on your server.
-      MSG
-    end
-
-    def api_key_exists?
-      ENV.key?('GOOGLE_MAPS_API_KEY')
     end
 
     class Query < T::Struct

--- a/lib/commands/google_maps_api.rb
+++ b/lib/commands/google_maps_api.rb
@@ -1,0 +1,29 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require_relative './base'
+require 'google-maps'
+
+Google::Maps.configure do |config|
+  config.authentication_mode = Google::Maps::Configuration::API_KEY
+  config.api_key = ENV['GOOGLE_MAPS_API_KEY']
+end
+
+module Commands
+  class GoogleMapsAPI < Base
+    private
+
+    def api_key_missing
+      <<~MSG
+        Your Google Maps API key is missing.
+        Create a new key at: https://developers.google.com/maps/gmp-get-started
+
+        Once you get a key, set it to ENV['GOOGLE_MAPS_API_KEY'] on your server.
+      MSG
+    end
+
+    def api_key_exists?
+      ENV.key?('GOOGLE_MAPS_API_KEY')
+    end
+  end
+end

--- a/sorbet/rbi/hidden-definitions/errors.txt
+++ b/sorbet/rbi/hidden-definitions/errors.txt
@@ -2320,6 +2320,7 @@
 # wrong constant name name
 # wrong constant name inherited
 # wrong constant name <static-init>
+# wrong constant name <static-init>
 # wrong constant name polar
 # wrong constant name rect
 # wrong constant name rectangular
@@ -2805,97 +2806,12 @@
 # wrong constant name stress=
 # wrong constant name verify_internal_consistency
 # wrong constant name verify_transient_heap_internal_consistency
-# wrong constant name <Class:S3URISigner>
-# wrong constant name <Class:UriParser>
-# wrong constant name <Class:UriParsing>
-# wrong constant name _deprecated_default_specifications_dir
-# undefined method `deprecate_option<defaultArg>1' for class `Gem::Command'
-# Did you mean?  deprecate_constant
-# undefined method `deprecate_option<defaultArg>2' for class `Gem::Command'
-# Did you mean?  deprecate_constant
-# undefined method `show_lookup_failure<defaultArg>2' for class `Gem::Command'
-# wrong constant name check_deprecated_options
-# wrong constant name deprecate_option<defaultArg>1
-# wrong constant name deprecate_option<defaultArg>2
-# wrong constant name deprecate_option
-# wrong constant name show_lookup_failure<defaultArg>2
-# wrong constant name <=>
-# wrong constant name identity
-# undefined method `_deprecated_find_gems_with_sources<defaultArg>1' for class `Gem::DependencyInstaller'
-# undefined method `_deprecated_find_spec_by_name_and_version<defaultArg>1' for class `Gem::DependencyInstaller'
-# undefined method `_deprecated_find_spec_by_name_and_version<defaultArg>2' for class `Gem::DependencyInstaller'
-# wrong constant name _deprecated_available_set_for
-# wrong constant name _deprecated_find_gems_with_sources<defaultArg>1
-# wrong constant name _deprecated_find_gems_with_sources
-# wrong constant name _deprecated_find_spec_by_name_and_version<defaultArg>1
-# wrong constant name _deprecated_find_spec_by_name_and_version<defaultArg>2
-# wrong constant name _deprecated_find_spec_by_name_and_version
-# wrong constant name _deprecated_unpack
-# wrong constant name package
-# wrong constant name gem
-# wrong constant name oct_or_256based
-# undefined singleton method `raw_spec<defaultArg>1' for `Gem::Package'
-# wrong constant name raw_spec<defaultArg>1
-# wrong constant name raw_spec
-# wrong constant name <Class:FetchError>
-# wrong constant name <Class:UnknownHostError>
-# wrong constant name _deprecated_fetch_size
-# wrong constant name s3_uri_signer
 # wrong constant name initialize
 # wrong constant name uri
 # wrong constant name uri=
 # wrong constant name <static-init>
 # wrong constant name <static-init>
-# wrong constant name default_prerelease
-# wrong constant name platform
 # uninitialized constant Gem::Resolver::Molinillo::DependencyGraph::Log::Elem
-# undefined method `sign<defaultArg>1' for class `Gem::S3URISigner'
-# wrong constant name <Class:ConfigurationError>
-# wrong constant name <Class:InstanceProfileError>
-# wrong constant name <Class:S3Config>
-# wrong constant name initialize
-# wrong constant name sign<defaultArg>1
-# wrong constant name sign
-# wrong constant name uri
-# wrong constant name uri=
-# wrong constant name initialize
-# wrong constant name <static-init>
-# wrong constant name initialize
-# wrong constant name <static-init>
-# uninitialized constant Gem::S3URISigner::S3Config::Elem
-# wrong constant name access_key_id
-# wrong constant name access_key_id=
-# wrong constant name region
-# wrong constant name region=
-# wrong constant name secret_access_key
-# wrong constant name secret_access_key=
-# wrong constant name security_token
-# wrong constant name security_token=
-# wrong constant name <static-init>
-# wrong constant name []
-# wrong constant name members
-# wrong constant name <static-init>
-# undefined method `typo_squatting?<defaultArg>1' for class `Gem::Source'
-# wrong constant name <=>
-# wrong constant name typo_squatting?<defaultArg>1
-# wrong constant name typo_squatting?
-# wrong constant name <=>
-# uninitialized constant Gem::Specification::GENERICS
-# uninitialized constant Gem::Specification::GENERIC_CACHE
-# wrong constant name _deprecated_rubyforge_project=
-# undefined singleton method `default_stubs<defaultArg>1' for `Gem::Specification'
-# wrong constant name default_stubs<defaultArg>1
-# wrong constant name default_stubs
-# wrong constant name parse
-# wrong constant name parse!
-# wrong constant name <static-init>
-# wrong constant name <static-init>
-# wrong constant name correct_for_windows_path
-# wrong constant name add_to_load_path
-# wrong constant name default_specifications_dir
-# wrong constant name java_platform?
-# wrong constant name source_date_epoch
-# wrong constant name suffix_regexp
 # uninitialized constant HTTP::Message::AddressableEnabled
 # uninitialized constant HTTPClient::AddressableEnabled
 # uninitialized constant HTTPClient::SSLConfig::AddressableEnabled
@@ -5336,7 +5252,7 @@
 # wrong constant name <static-init>
 # wrong constant name worse_than?
 # wrong constant name +
-# uninitialized constant #<Class:0x00007fbfabb8ed78>::Elem
+# uninitialized constant #<Class:0x00007fb8e79395c0>::Elem
 # wrong constant name candidate?
 # wrong constant name ideal?
 # wrong constant name indeterminate_actual_indexes

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -2742,6 +2742,9 @@ class Commands::Base
   def self.name(*args, &blk); end
 end
 
+class Commands::Details
+end
+
 class Commands::Directions
 end
 
@@ -2761,6 +2764,12 @@ class Commands::Directions::RoutePresenter
   extend ::T::Private::Methods::SingletonMethodHooks
 end
 
+class Commands::GoogleMapsAPI
+end
+
+class Commands::GoogleMapsAPI
+end
+
 class Commands::Help
 end
 
@@ -2768,6 +2777,9 @@ class Commands::Ping
 end
 
 class Commands::Ping
+end
+
+class Commands::Tip
 end
 
 module Commands
@@ -2816,7 +2828,6 @@ class Delegator
   def protected_methods(all=T.unsafe(nil)); end
 
   def public_methods(all=T.unsafe(nil)); end
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
 class Delegator
@@ -2951,8 +2962,6 @@ class ERB::Compiler::Scanner
   DEFAULT_ETAGS = ::T.let(nil, ::T.untyped)
   DEFAULT_STAGS = ::T.let(nil, ::T.untyped)
 end
-
-Emitter = Psych::Stream::Emitter
 
 class Encoding
   def _dump(*_); end
@@ -3833,60 +3842,7 @@ module GC
   def self.verify_transient_heap_internal_consistency(); end
 end
 
-module Gem
-  UNTAINT = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::BasicSpecification
-  def self._deprecated_default_specifications_dir(); end
-end
-
-class Gem::Command
-  def check_deprecated_options(options); end
-
-  def deprecate_option(name, version: T.unsafe(nil), extra_msg: T.unsafe(nil)); end
-
-end
-
-class Gem::Dependency
-  def identity(); end
-end
-
-class Gem::DependencyInstaller
-  def _deprecated_available_set_for(dep_or_name, version); end
-
-  def _deprecated_find_gems_with_sources(dep, best_only=T.unsafe(nil)); end
-
-  def _deprecated_find_spec_by_name_and_version(gem_name, version=T.unsafe(nil), prerelease=T.unsafe(nil)); end
-end
-
-class Gem::Installer
-  def _deprecated_unpack(directory); end
-
-  def package(); end
-end
-
-class Gem::Package
-  def gem(); end
-end
-
-class Gem::Package::TarHeader
-  def self.oct_or_256based(str); end
-end
-
-class Gem::Package
-  def self.raw_spec(path, security_policy=T.unsafe(nil)); end
-end
-
-class Gem::RemoteFetcher
-  include ::Gem::UriParsing
-  def _deprecated_fetch_size(uri); end
-
-  def s3_uri_signer(uri); end
-end
-
 class Gem::RemoteFetcher::FetchError
-  include ::Gem::UriParsing
   def initialize(message, uri); end
 
   def uri(); end
@@ -3903,130 +3859,12 @@ end
 class Gem::RemoteFetcher::UnknownHostError
 end
 
-class Gem::RemoteFetcher
-  extend ::Gem::Deprecate
-end
-
-class Gem::Requirement
-  DefaultPrereleaseRequirement = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::Requirement
-  def self.default_prerelease(); end
-end
-
-class Gem::Resolver::ActivationRequest
-  def platform(); end
-end
-
 class Gem::Resolver::Molinillo::DependencyGraph::Log
   extend ::Enumerable
 end
 
-class Gem::S3URISigner
-  def initialize(uri); end
-
-  def sign(expiration=T.unsafe(nil)); end
-
-  def uri(); end
-
-  def uri=(uri); end
-  BASE64_URI_TRANSLATE = ::T.let(nil, ::T.untyped)
-  EC2_IAM_INFO = ::T.let(nil, ::T.untyped)
-  EC2_IAM_SECURITY_CREDENTIALS = ::T.let(nil, ::T.untyped)
-end
-
-class Gem::S3URISigner::ConfigurationError
-  def initialize(message); end
-end
-
-class Gem::S3URISigner::ConfigurationError
-end
-
-class Gem::S3URISigner::InstanceProfileError
-  def initialize(message); end
-end
-
-class Gem::S3URISigner::InstanceProfileError
-end
-
-class Gem::S3URISigner::S3Config
-  def access_key_id(); end
-
-  def access_key_id=(_); end
-
-  def region(); end
-
-  def region=(_); end
-
-  def secret_access_key(); end
-
-  def secret_access_key=(_); end
-
-  def security_token(); end
-
-  def security_token=(_); end
-end
-
-class Gem::S3URISigner::S3Config
-  def self.[](*_); end
-
-  def self.members(); end
-end
-
-class Gem::S3URISigner
-end
-
-class Gem::Source
-  include ::Gem::Text
-  def typo_squatting?(host, distance_threshold=T.unsafe(nil)); end
-end
-
-class Gem::Specification
-  def _deprecated_rubyforge_project=(_deprecated_rubyforge_project); end
-  LOAD_CACHE_MUTEX = ::T.let(nil, ::T.untyped)
-end
-
 class Gem::Specification
   extend ::Enumerable
-  def self.default_stubs(pattern=T.unsafe(nil)); end
-end
-
-class Gem::SpecificationPolicy
-  include ::Gem::UserInteraction
-  include ::Gem::DefaultUserInteraction
-  include ::Gem::Text
-end
-
-class Gem::UriParser
-  def parse(uri); end
-
-  def parse!(uri); end
-end
-
-class Gem::UriParser
-end
-
-module Gem::UriParsing
-end
-
-module Gem::UriParsing
-end
-
-module Gem::Util
-  def self.correct_for_windows_path(path); end
-end
-
-module Gem
-  def self.add_to_load_path(*paths); end
-
-  def self.default_specifications_dir(); end
-
-  def self.java_platform?(); end
-
-  def self.source_date_epoch(); end
-
-  def self.suffix_regexp(); end
 end
 
 class Google::Maps::API
@@ -4333,6 +4171,7 @@ class Integer
   def pow(*_); end
 
   def to_bn(); end
+  GMP_VERSION = ::T.let(nil, ::T.untyped)
 end
 
 class Integer
@@ -4357,8 +4196,6 @@ class JSONClient
   CONTENT_TYPE_JSON = ::T.let(nil, ::T.untyped)
   CONTENT_TYPE_JSON_REGEX = ::T.let(nil, ::T.untyped)
 end
-
-JSONTree = Psych::Visitors::JSONTree
 
 module JWT::Algos::Ecdsa
   NAMED_CURVES = ::T.let(nil, ::T.untyped)
@@ -4545,57 +4382,12 @@ module Mustermann
   DEFAULT_TYPE = ::T.let(nil, ::T.untyped)
 end
 
-class Mustermann::AST::Boundaries::NodeTranslator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::Expander::NodeTranslator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::ParamScanner::NodeTranslator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
 class Mustermann::AST::Pattern
   extend ::SingleForwardable
 end
 
-class Mustermann::AST::TemplateGenerator::NodeTranslator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::Transformer::ArrayTransform
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
 class Mustermann::AST::Transformer::ExpressionTransform
   OPERATORS = ::T.let(nil, ::T.untyped)
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::Transformer::GroupTransformer
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::Transformer::NodeTranslator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::Transformer::RootTransformer
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::Translator::NodeTranslator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::AST::Validation::NodeTranslator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class Mustermann::Caster
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
 module Mutex_m
@@ -5382,6 +5174,11 @@ class Pathname
   def glob(*_); end
 
   def make_symlink(_); end
+end
+
+class PhoneWhitelist
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
 end
 
 class Proc
@@ -10425,10 +10222,6 @@ class Rack::Session::Abstract::SessionHash
   Unspecified = ::T.let(nil, ::T.untyped)
 end
 
-class Rack::Session::Cookie::SessionId
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
 class Rack::Session::Pool
   def delete_session(req, session_id, options); end
 
@@ -10706,10 +10499,6 @@ class SignalException
   def signm(); end
 
   def signo(); end
-end
-
-class SimpleDelegator
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
 module Sinatra
@@ -11553,7 +11342,6 @@ class Tempfile
   def _close(); end
 
   def inspect(); end
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
 class Tempfile::Remover
@@ -11960,10 +11748,6 @@ class VCR::Errors::UnhandledHTTPRequestError
   ALL_SUGGESTIONS = ::T.let(nil, ::T.untyped)
 end
 
-class VCR::HTTPInteraction::HookAware
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
 module VCR::InternetConnection
   def available?(); end
   EXAMPLE_HOST = ::T.let(nil, ::T.untyped)
@@ -11971,10 +11755,6 @@ end
 
 module VCR::InternetConnection
   extend ::VCR::InternetConnection
-end
-
-class VCR::LinkedCassette
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
 end
 
 class VCR::Middleware::Faraday
@@ -12016,14 +11796,6 @@ module VCR::RSpec::Metadata
   extend ::VCR::RSpec::Metadata
 end
 
-class VCR::Request::FiberAware
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
-class VCR::Request::Typed
-  RUBYGEMS_ACTIVATION_MONITOR = ::T.let(nil, ::T.untyped)
-end
-
 class VCR::RequestIgnorer
   LOCALHOST_ALIASES = ::T.let(nil, ::T.untyped)
 end
@@ -12035,8 +11807,6 @@ end
 class VCR::Response
   HAVE_ZLIB = ::T.let(nil, ::T.untyped)
 end
-
-Visitor = Psych::Visitors::Visitor
 
 module Warning
   def warn(_); end
@@ -12087,8 +11857,6 @@ module WebMock::Util::URI::CharacterClasses
 end
 
 YAML = Psych
-
-YAMLTree = Psych::Visitors::YAMLTree
 
 module Zlib
   ASCII = ::T.let(nil, ::T.untyped)

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -8,6 +8,9 @@ module ::Anonymous_Delegator_18; end
 module ::Anonymous_Delegator_2; end
 module ::Anonymous_Delegator_22; end
 module ::Anonymous_Delegator_3; end
+module Commands::Directions::Mode::Bicycling; end
+module Commands::Directions::Mode::Transit; end
+module Commands::Directions::Mode::Walking; end
 module Compare::Boolean; end
 module Compare::Boolean; end
 module Compare::Boolean; end
@@ -18,6 +21,8 @@ module T::Private::Methods::MethodHooks; end
 module T::Private::Methods::MethodHooks; end
 module T::Private::Methods::MethodHooks; end
 module T::Private::Methods::MethodHooks; end
+module T::Private::Methods::MethodHooks; end
+module T::Private::Methods::SingletonMethodHooks; end
 module T::Private::Methods::SingletonMethodHooks; end
 module T::Private::Methods::SingletonMethodHooks; end
 module T::Private::Methods::SingletonMethodHooks; end

--- a/spec/fixtures/vcr_cassettes/details_multiple.yml
+++ b/spec/fixtures/vcr_cassettes/details_multiple.yml
@@ -1,0 +1,597 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/place/autocomplete/json?input=korean%20restaurant,%20victoria%20bc&key=<GOOGLE
+      MAPS API KEY>&language=en
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.6.3 (2019-04-16))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 04 Feb 2020 01:32:14 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 04 Feb 2020 01:32:14 GMT
+      Expires:
+      - Tue, 04 Feb 2020 01:32:14 GMT
+      Cache-Control:
+      - private, max-age=300
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=49
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443";
+        ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443";
+        ma=2592000
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "predictions" : [
+              {
+                 "description" : "NARU Korean Restaurant, Wharf Street, Victoria, BC, Canada",
+                 "id" : "60cefdab8e9827bd470184a6d37958a9c796f111",
+                 "matched_substrings" : [
+                    {
+                       "length" : 17,
+                       "offset" : 5
+                    },
+                    {
+                       "length" : 8,
+                       "offset" : 38
+                    },
+                    {
+                       "length" : 2,
+                       "offset" : 48
+                    }
+                 ],
+                 "place_id" : "ChIJsTuRCYV1j1QRXsKUhvyChQQ",
+                 "reference" : "ChIJsTuRCYV1j1QRXsKUhvyChQQ",
+                 "structured_formatting" : {
+                    "main_text" : "NARU Korean Restaurant",
+                    "main_text_matched_substrings" : [
+                       {
+                          "length" : 17,
+                          "offset" : 5
+                       }
+                    ],
+                    "secondary_text" : "Wharf Street, Victoria, BC, Canada",
+                    "secondary_text_matched_substrings" : [
+                       {
+                          "length" : 8,
+                          "offset" : 14
+                       },
+                       {
+                          "length" : 2,
+                          "offset" : 24
+                       }
+                    ]
+                 },
+                 "terms" : [
+                    {
+                       "offset" : 0,
+                       "value" : "NARU Korean Restaurant"
+                    },
+                    {
+                       "offset" : 24,
+                       "value" : "Wharf Street"
+                    },
+                    {
+                       "offset" : 38,
+                       "value" : "Victoria"
+                    },
+                    {
+                       "offset" : 48,
+                       "value" : "BC"
+                    },
+                    {
+                       "offset" : 52,
+                       "value" : "Canada"
+                    }
+                 ],
+                 "types" : [ "restaurant", "food", "point_of_interest", "establishment" ]
+              },
+              {
+                 "description" : "Cera Korean Restaurant, Pandora Avenue, Victoria, BC, Canada",
+                 "id" : "76bfbd0ff17039ea5cdceb909a48d53934f6c643",
+                 "matched_substrings" : [
+                    {
+                       "length" : 17,
+                       "offset" : 5
+                    },
+                    {
+                       "length" : 8,
+                       "offset" : 40
+                    },
+                    {
+                       "length" : 2,
+                       "offset" : 50
+                    }
+                 ],
+                 "place_id" : "ChIJR2MogR11j1QRJe8oTjIrG8Y",
+                 "reference" : "ChIJR2MogR11j1QRJe8oTjIrG8Y",
+                 "structured_formatting" : {
+                    "main_text" : "Cera Korean Restaurant",
+                    "main_text_matched_substrings" : [
+                       {
+                          "length" : 17,
+                          "offset" : 5
+                       }
+                    ],
+                    "secondary_text" : "Pandora Avenue, Victoria, BC, Canada",
+                    "secondary_text_matched_substrings" : [
+                       {
+                          "length" : 8,
+                          "offset" : 16
+                       },
+                       {
+                          "length" : 2,
+                          "offset" : 26
+                       }
+                    ]
+                 },
+                 "terms" : [
+                    {
+                       "offset" : 0,
+                       "value" : "Cera Korean Restaurant"
+                    },
+                    {
+                       "offset" : 24,
+                       "value" : "Pandora Avenue"
+                    },
+                    {
+                       "offset" : 40,
+                       "value" : "Victoria"
+                    },
+                    {
+                       "offset" : 50,
+                       "value" : "BC"
+                    },
+                    {
+                       "offset" : 54,
+                       "value" : "Canada"
+                    }
+                 ],
+                 "types" : [ "restaurant", "food", "point_of_interest", "establishment" ]
+              },
+              {
+                 "description" : "Han Korean Restaurant, Johnson Street, Victoria, BC, Canada",
+                 "id" : "53d32b5baca90488e0daeb055cbd4e16724b3bb5",
+                 "matched_substrings" : [
+                    {
+                       "length" : 17,
+                       "offset" : 4
+                    },
+                    {
+                       "length" : 8,
+                       "offset" : 39
+                    },
+                    {
+                       "length" : 2,
+                       "offset" : 49
+                    }
+                 ],
+                 "place_id" : "ChIJJbqn3IR0j1QRGe2nv6KlIkU",
+                 "reference" : "ChIJJbqn3IR0j1QRGe2nv6KlIkU",
+                 "structured_formatting" : {
+                    "main_text" : "Han Korean Restaurant",
+                    "main_text_matched_substrings" : [
+                       {
+                          "length" : 17,
+                          "offset" : 4
+                       }
+                    ],
+                    "secondary_text" : "Johnson Street, Victoria, BC, Canada",
+                    "secondary_text_matched_substrings" : [
+                       {
+                          "length" : 8,
+                          "offset" : 16
+                       },
+                       {
+                          "length" : 2,
+                          "offset" : 26
+                       }
+                    ]
+                 },
+                 "terms" : [
+                    {
+                       "offset" : 0,
+                       "value" : "Han Korean Restaurant"
+                    },
+                    {
+                       "offset" : 23,
+                       "value" : "Johnson Street"
+                    },
+                    {
+                       "offset" : 39,
+                       "value" : "Victoria"
+                    },
+                    {
+                       "offset" : 49,
+                       "value" : "BC"
+                    },
+                    {
+                       "offset" : 53,
+                       "value" : "Canada"
+                    }
+                 ],
+                 "types" : [ "restaurant", "food", "point_of_interest", "establishment" ]
+              },
+              {
+                 "description" : "Sura Korean Restaurant, Douglas Street, Victoria, BC, Canada",
+                 "id" : "49fc46c725531e132182168f898b8e788853ce4e",
+                 "matched_substrings" : [
+                    {
+                       "length" : 17,
+                       "offset" : 5
+                    },
+                    {
+                       "length" : 8,
+                       "offset" : 40
+                    },
+                    {
+                       "length" : 2,
+                       "offset" : 50
+                    }
+                 ],
+                 "place_id" : "ChIJ-6Z5b4R0j1QRspOwslFuhQc",
+                 "reference" : "ChIJ-6Z5b4R0j1QRspOwslFuhQc",
+                 "structured_formatting" : {
+                    "main_text" : "Sura Korean Restaurant",
+                    "main_text_matched_substrings" : [
+                       {
+                          "length" : 17,
+                          "offset" : 5
+                       }
+                    ],
+                    "secondary_text" : "Douglas Street, Victoria, BC, Canada",
+                    "secondary_text_matched_substrings" : [
+                       {
+                          "length" : 8,
+                          "offset" : 16
+                       },
+                       {
+                          "length" : 2,
+                          "offset" : 26
+                       }
+                    ]
+                 },
+                 "terms" : [
+                    {
+                       "offset" : 0,
+                       "value" : "Sura Korean Restaurant"
+                    },
+                    {
+                       "offset" : 24,
+                       "value" : "Douglas Street"
+                    },
+                    {
+                       "offset" : 40,
+                       "value" : "Victoria"
+                    },
+                    {
+                       "offset" : 50,
+                       "value" : "BC"
+                    },
+                    {
+                       "offset" : 54,
+                       "value" : "Canada"
+                    }
+                 ],
+                 "types" : [ "restaurant", "food", "point_of_interest", "establishment" ]
+              },
+              {
+                 "description" : "Sumi Korean Restaurant, Victoria Drive, Vancouver, BC, Canada",
+                 "id" : "39e2cece4b42ecf0ec66f15d6295d9e2fc539160",
+                 "matched_substrings" : [
+                    {
+                       "length" : 17,
+                       "offset" : 5
+                    },
+                    {
+                       "length" : 8,
+                       "offset" : 24
+                    },
+                    {
+                       "length" : 2,
+                       "offset" : 51
+                    }
+                 ],
+                 "place_id" : "ChIJcaBgLwh1hlQRp2UdMmvM6SI",
+                 "reference" : "ChIJcaBgLwh1hlQRp2UdMmvM6SI",
+                 "structured_formatting" : {
+                    "main_text" : "Sumi Korean Restaurant",
+                    "main_text_matched_substrings" : [
+                       {
+                          "length" : 17,
+                          "offset" : 5
+                       }
+                    ],
+                    "secondary_text" : "Victoria Drive, Vancouver, BC, Canada",
+                    "secondary_text_matched_substrings" : [
+                       {
+                          "length" : 8,
+                          "offset" : 0
+                       },
+                       {
+                          "length" : 2,
+                          "offset" : 27
+                       }
+                    ]
+                 },
+                 "terms" : [
+                    {
+                       "offset" : 0,
+                       "value" : "Sumi Korean Restaurant"
+                    },
+                    {
+                       "offset" : 24,
+                       "value" : "Victoria Drive"
+                    },
+                    {
+                       "offset" : 40,
+                       "value" : "Vancouver"
+                    },
+                    {
+                       "offset" : 51,
+                       "value" : "BC"
+                    },
+                    {
+                       "offset" : 55,
+                       "value" : "Canada"
+                    }
+                 ],
+                 "types" : [ "restaurant", "food", "point_of_interest", "establishment" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Tue, 04 Feb 2020 01:32:14 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/place/details/json?key=<GOOGLE MAPS
+      API KEY>&language=en&placeid=ChIJsTuRCYV1j1QRXsKUhvyChQQ
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.6.3 (2019-04-16))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 04 Feb 2020 01:32:14 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 04 Feb 2020 01:30:39 GMT
+      Expires:
+      - Tue, 04 Feb 2020 01:35:39 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=265
+      Cache-Control:
+      - public, max-age=300
+      Age:
+      - '96'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443";
+        ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443";
+        ma=2592000
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "{\n   \"html_attributions\" : [],\n   \"result\" : {\n      \"address_components\"
+        : [\n         {\n            \"long_name\" : \"1218\",\n            \"short_name\"
+        : \"1218\",\n            \"types\" : [ \"street_number\" ]\n         },\n
+        \        {\n            \"long_name\" : \"Wharf Street\",\n            \"short_name\"
+        : \"Wharf St\",\n            \"types\" : [ \"route\" ]\n         },\n         {\n
+        \           \"long_name\" : \"Downtown\",\n            \"short_name\" : \"Downtown\",\n
+        \           \"types\" : [ \"neighborhood\", \"political\" ]\n         },\n
+        \        {\n            \"long_name\" : \"Victoria\",\n            \"short_name\"
+        : \"Victoria\",\n            \"types\" : [ \"locality\", \"political\" ]\n
+        \        },\n         {\n            \"long_name\" : \"Capital\",\n            \"short_name\"
+        : \"CRD\",\n            \"types\" : [ \"administrative_area_level_2\", \"political\"
+        ]\n         },\n         {\n            \"long_name\" : \"British Columbia\",\n
+        \           \"short_name\" : \"BC\",\n            \"types\" : [ \"administrative_area_level_1\",
+        \"political\" ]\n         },\n         {\n            \"long_name\" : \"Canada\",\n
+        \           \"short_name\" : \"CA\",\n            \"types\" : [ \"country\",
+        \"political\" ]\n         },\n         {\n            \"long_name\" : \"V8W
+        1T8\",\n            \"short_name\" : \"V8W 1T8\",\n            \"types\" :
+        [ \"postal_code\" ]\n         }\n      ],\n      \"adr_address\" : \"\\u003cspan
+        class=\\\"street-address\\\"\\u003e1218 Wharf St\\u003c/span\\u003e, \\u003cspan
+        class=\\\"locality\\\"\\u003eVictoria\\u003c/span\\u003e, \\u003cspan class=\\\"region\\\"\\u003eBC\\u003c/span\\u003e
+        \\u003cspan class=\\\"postal-code\\\"\\u003eV8W 1T8\\u003c/span\\u003e, \\u003cspan
+        class=\\\"country-name\\\"\\u003eCanada\\u003c/span\\u003e\",\n      \"formatted_address\"
+        : \"1218 Wharf St, Victoria, BC V8W 1T8, Canada\",\n      \"formatted_phone_number\"
+        : \"(250) 590-5298\",\n      \"geometry\" : {\n         \"location\" : {\n
+        \           \"lat\" : 48.426445,\n            \"lng\" : -123.370475\n         },\n
+        \        \"viewport\" : {\n            \"northeast\" : {\n               \"lat\"
+        : 48.4278221302915,\n               \"lng\" : -123.3689770197085\n            },\n
+        \           \"southwest\" : {\n               \"lat\" : 48.4251241697085,\n
+        \              \"lng\" : -123.3716749802915\n            }\n         }\n      },\n
+        \     \"icon\" : \"https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png\",\n
+        \     \"id\" : \"60cefdab8e9827bd470184a6d37958a9c796f111\",\n      \"international_phone_number\"
+        : \"+1 250-590-5298\",\n      \"name\" : \"NARU Korean Restaurant\",\n      \"opening_hours\"
+        : {\n         \"open_now\" : true,\n         \"periods\" : [\n            {\n
+        \              \"close\" : {\n                  \"day\" : 1,\n                  \"time\"
+        : \"1600\"\n               },\n               \"open\" : {\n                  \"day\"
+        : 1,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 1,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 1,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 2,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 2,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 2,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 2,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 3,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 3,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 3,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 3,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 4,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 4,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 4,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 4,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 5,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 5,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 5,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 5,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 6,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 6,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 6,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 6,\n                  \"time\" : \"1700\"\n
+        \              }\n            }\n         ],\n         \"weekday_text\" :
+        [\n            \"Monday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n            \"Tuesday:
+        11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n            \"Wednesday: 11:30 AM –
+        4:00 PM, 5:00 – 9:30 PM\",\n            \"Thursday: 11:30 AM – 4:00 PM, 5:00
+        – 9:30 PM\",\n            \"Friday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n
+        \           \"Saturday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n            \"Sunday:
+        Closed\"\n         ]\n      },\n      \"photos\" : [\n         {\n            \"height\"
+        : 3024,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAyipALrR4oACjsWaMTj1KHgmsgHtavtkBW4LlwGHflp3czKxQmN3wgO_biBFc4V03f1_Y4LyUMK6lV8DRHeNsnMLDY697nJUAeqfYXGF34cDyWc4sITfSkWE_-1EyDjvqEhA90UIX6YTFeJkJ6Jn_B1gGGhSoZKEHizNRXRhZSpnlyQOCuXML2g\",\n
+        \           \"width\" : 4032\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAdZxzj21eH7k3SyfQ07ROfSyKn9_nKBNckdyEied3_KDNrnAGtRuBs0Q-l7apUCkuUCcuYT66NxjaAlZ6oSwVbYGgHYie2HiyIWfH83ftBEFNdMpht37CPTrKIR3jvO8nEhCsArINdeXVgvOQHwmu6m_OGhT5aVZtfD8gSTBHG6GjYgFLtYrLuA\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 4032,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/108119494912502779918\\\"\\u003elucy
+        byun\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\" :
+        \"CmRaAAAAZMgCM9LkoDX2tcxPRD770t2misrkw31AQ65VdLfhNFY3fPtis4W_QD46WaAIufpvwWgmpQRoWItr5AJivZ_EUysbWXr2lT02jusHCVsOo3m0_b6l7bob4Dn4--Mar3E1EhCZoelPDSN5LGCP9ShcWvyJGhSB6FHJ_vh8FQ4aQ_pwPj1ndYyYBg\",\n
+        \           \"width\" : 3024\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAPJy7N0mueO2x5awlEjM3VqVLAQS1eM01yOeSek_phIFeZv8ju-jiOZRtGCTT-HwmVNr08SMcuB6zmJcfXNcoAuHAd_Cgf30aRWhezE_OGjP25SxgX-NUzKMuDcUMS-IqEhDeyt7FiBNsPIh1j8uRLcDtGhR7zel3MD_IDCKVGwywoL2-zY0jRA\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAA6qVRwvhSAGw6UwZx7z8K9Gid1aqBiQ8hAg7BTYKKPIZxy6QFAxwVp5oXnjzaYDZqKTuwBSqrZQlr-0IqJEbsuw8KlUkqNGYJ2SHaSGLOy2lchBElJeQv9sV-JRDrCGCcEhBC-3UMWvgixFm6igWZXycaGhSBoY8PG30_GChA22OWQy1ImSdpUg\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 1536,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/103885090727600394266\\\"\\u003eyong
+        wan cho\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRaAAAANqzm51DZ973nNSjZv6pUCLVMeoSQ0DIRsBW6O0pRHgBofxtFT6fn8_uthmml4-zsNVCHGVccPUMAs196RfBMCSse4Y6f8nXkMC7I4sQUCkTFmpYLFBQhNeK9YSL4OEUbEhBTuG68YBG3Q9idLkj1BpmvGhS17CMg_yDruqHYyAhNjKkXXz1HMQ\",\n
+        \           \"width\" : 2048\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAyvk_8WDcf3QIm7Dm4Z5q_rWuHT3IE_VbPHewJ6Z_Zc1JJ4zr_gBnDNvayVKrZUQL03N5mgn_tV-KEmMAUC8SUYVeClJxsD3zdp8LD4wd9obP0MsNGyY9q2vQ4MVZerSXEhCDYi9Rcg31aNli7ya1nz6cGhSJDCujXDjypHaIT2ZaSRba1X2TwQ\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAArnxU5rNzwcpZPUcQtBAZB08g8Rh6m4OHJXL5wG5egv85uXgK-HSliYBTzMX-xfZlU_s2p_ygWf-NCuzW_MCj_hvYQ8cb7fAL3AWKTzNBcj-6iOR15b6lyypJhwiMS66DEhCCnsgoUwpjZBDgU6UOyZ2gGhTZIjcVeLVIQyDWqT7podqZ1ymsiQ\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 2048,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/103885090727600394266\\\"\\u003eyong
+        wan cho\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRaAAAAQjL3UPyy2NYrrDyvDYBKNaxWTBBFdotYZuqXl_onz4upHMq4SGXxjsfcIFgDvBWZyBhPsbfdUK-5fLN2M9SR5fg_seZ83HbusBCWStUPZjSkjUfGuqb1XpWf9i2AEg82EhDX9mhbrd8OKr84obN4I-vVGhQytwmBmxzzT0O7qknPm1FUk5tQkg\",\n
+        \           \"width\" : 1536\n         },\n         {\n            \"height\"
+        : 961,\n            \"html_attributions\" : [\n               \"\\u003ca href=\\\"https://maps.google.com/maps/contrib/104570750953545296721\\\"\\u003eKyou
+        Park\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\" :
+        \"CmRaAAAAgySR8FkE4cCOKLJso2e5MA9sjvTIq5xSUC43AZkbPGm77NDrjWVIy86hCTOM8FuJF3PiOQ9k8vUGepvgN8Igztvyl32mbPGkixZRaGjQMvWXB1MS4nmpnDfOEIqk2rMyEhDuCWbz0qVqn1azj8xxO_esGhRrIXzEV4BN1qUdDZpex-Y6DWagJg\",\n
+        \           \"width\" : 961\n         }\n      ],\n      \"place_id\" : \"ChIJsTuRCYV1j1QRXsKUhvyChQQ\",\n
+        \     \"plus_code\" : {\n         \"compound_code\" : \"CJGH+HR Victoria,
+        British Columbia, Canada\",\n         \"global_code\" : \"84WRCJGH+HR\"\n
+        \     },\n      \"rating\" : 4.5,\n      \"reference\" : \"ChIJsTuRCYV1j1QRXsKUhvyChQQ\",\n
+        \     \"reviews\" : [\n         {\n            \"author_name\" : \"Anisa _\",\n
+        \           \"author_url\" : \"https://www.google.com/maps/contrib/112753285667148678497/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh3.ggpht.com/-jZkZHYANdfw/AAAAAAAAAAI/AAAAAAAAAAA/xZfa87Pp_gE/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"3
+        months ago\",\n            \"text\" : \"Got the hot pot and it was amazing!
+        I’ve had much fair share of Korean food and this place was great. Such a good
+        amount of food and super flavourful. Plus I love the set up of the restaurant
+        itself with the high ceilings and big windows. Good service too \U0001F60A\",\n
+        \           \"time\" : 1572541107\n         },\n         {\n            \"author_name\"
+        : \"Sally Lin\",\n            \"author_url\" : \"https://www.google.com/maps/contrib/104366231054072771635/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh3.ggpht.com/-ngv2j3AdLeQ/AAAAAAAAAAI/AAAAAAAAAAA/uKmZT_yweuU/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"3
+        months ago\",\n            \"text\" : \"The hot pot dishes are really good!
+        Friendly service too. Best Korean food I’ve had in Victoria and I’ve tried
+        a few different places. This restaurant is Vancouver-level good and I lived
+        there for 5 years. Really glad Victoria is lucky enough to have Naru join
+        the restaurant scene! \U0001F642\",\n            \"time\" : 1571804196\n         },\n
+        \        {\n            \"author_name\" : \"Monica W\",\n            \"author_url\"
+        : \"https://www.google.com/maps/contrib/112440640190488425281/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh6.ggpht.com/-BTxWIXo2TGo/AAAAAAAAAAI/AAAAAAAAAAA/82bswRXLfUU/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"a
+        month ago\",\n            \"text\" : \"We had an excellent meal as a group
+        of 8. Reasonably priced and great staff.\",\n            \"time\" : 1576445864\n
+        \        },\n         {\n            \"author_name\" : \"Amy L\",\n            \"author_url\"
+        : \"https://www.google.com/maps/contrib/103882966574906704924/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh4.ggpht.com/-DiP0RyXupTA/AAAAAAAAAAI/AAAAAAAAAAA/UyrvAUqIDKI/s128-c0x00000000-cc-rp-mo-ba3/photo.jpg\",\n
+        \           \"rating\" : 4,\n            \"relative_time_description\" : \"2
+        months ago\",\n            \"text\" : \"Possam is a favorite of ours and it
+        was tasty. Can't wait to come back and try so many delicacies.  Very clean,
+        fast and excellent service.\",\n            \"time\" : 1573893212\n         },\n
+        \        {\n            \"author_name\" : \"Sarah Graham\",\n            \"author_url\"
+        : \"https://www.google.com/maps/contrib/100414946235174593274/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh3.ggpht.com/-kIQXPD6XPXE/AAAAAAAAAAI/AAAAAAAAAAA/uhIR_iODSJk/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"a
+        month ago\",\n            \"text\" : \"Great service and amazingly delicious
+        food! And great atmosphere!\",\n            \"time\" : 1576386722\n         }\n
+        \     ],\n      \"scope\" : \"GOOGLE\",\n      \"types\" : [ \"restaurant\",
+        \"food\", \"point_of_interest\", \"establishment\" ],\n      \"url\" : \"https://maps.google.com/?cid=325810569155494494\",\n
+        \     \"user_ratings_total\" : 80,\n      \"utc_offset\" : -480,\n      \"vicinity\"
+        : \"1218 Wharf Street, Victoria\"\n   },\n   \"status\" : \"OK\"\n}\n"
+    http_version: 
+  recorded_at: Tue, 04 Feb 2020 01:32:15 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/details_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/details_not_found.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/place/autocomplete/json?input=00000000000000000000&key=<GOOGLE
+      MAPS API KEY>&language=en
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.6.3 (2019-04-16))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 04 Feb 2020 01:22:24 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 04 Feb 2020 01:22:25 GMT
+      Expires:
+      - Tue, 04 Feb 2020 01:22:25 GMT
+      Cache-Control:
+      - private, max-age=300
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=59
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443";
+        ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443";
+        ma=2592000
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "predictions" : [],
+           "status" : "ZERO_RESULTS"
+        }
+    http_version: 
+  recorded_at: Tue, 04 Feb 2020 01:22:25 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/details_single.yml
+++ b/spec/fixtures/vcr_cassettes/details_single.yml
@@ -1,0 +1,345 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/place/autocomplete/json?input=naru%20victoria%20bc&key=<GOOGLE
+      MAPS API KEY>&language=en
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.6.3 (2019-04-16))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 04 Feb 2020 01:33:09 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 04 Feb 2020 01:33:09 GMT
+      Expires:
+      - Tue, 04 Feb 2020 01:33:09 GMT
+      Cache-Control:
+      - private, max-age=300
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=56
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443";
+        ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443";
+        ma=2592000
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "predictions" : [
+              {
+                 "description" : "NARU Korean Restaurant, Wharf Street, Victoria, BC, Canada",
+                 "id" : "60cefdab8e9827bd470184a6d37958a9c796f111",
+                 "matched_substrings" : [
+                    {
+                       "length" : 4,
+                       "offset" : 0
+                    },
+                    {
+                       "length" : 8,
+                       "offset" : 38
+                    },
+                    {
+                       "length" : 2,
+                       "offset" : 48
+                    }
+                 ],
+                 "place_id" : "ChIJsTuRCYV1j1QRXsKUhvyChQQ",
+                 "reference" : "ChIJsTuRCYV1j1QRXsKUhvyChQQ",
+                 "structured_formatting" : {
+                    "main_text" : "NARU Korean Restaurant",
+                    "main_text_matched_substrings" : [
+                       {
+                          "length" : 4,
+                          "offset" : 0
+                       }
+                    ],
+                    "secondary_text" : "Wharf Street, Victoria, BC, Canada",
+                    "secondary_text_matched_substrings" : [
+                       {
+                          "length" : 8,
+                          "offset" : 14
+                       },
+                       {
+                          "length" : 2,
+                          "offset" : 24
+                       }
+                    ]
+                 },
+                 "terms" : [
+                    {
+                       "offset" : 0,
+                       "value" : "NARU Korean Restaurant"
+                    },
+                    {
+                       "offset" : 24,
+                       "value" : "Wharf Street"
+                    },
+                    {
+                       "offset" : 38,
+                       "value" : "Victoria"
+                    },
+                    {
+                       "offset" : 48,
+                       "value" : "BC"
+                    },
+                    {
+                       "offset" : 52,
+                       "value" : "Canada"
+                    }
+                 ],
+                 "types" : [ "restaurant", "food", "point_of_interest", "establishment" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Tue, 04 Feb 2020 01:33:09 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/place/details/json?key=<GOOGLE MAPS
+      API KEY>&language=en&placeid=ChIJsTuRCYV1j1QRXsKUhvyChQQ
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.6.3 (2019-04-16))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 04 Feb 2020 01:33:10 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 04 Feb 2020 01:30:39 GMT
+      Expires:
+      - Tue, 04 Feb 2020 01:35:39 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=265
+      Cache-Control:
+      - public, max-age=300
+      Age:
+      - '151'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443";
+        ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443";
+        ma=2592000
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "{\n   \"html_attributions\" : [],\n   \"result\" : {\n      \"address_components\"
+        : [\n         {\n            \"long_name\" : \"1218\",\n            \"short_name\"
+        : \"1218\",\n            \"types\" : [ \"street_number\" ]\n         },\n
+        \        {\n            \"long_name\" : \"Wharf Street\",\n            \"short_name\"
+        : \"Wharf St\",\n            \"types\" : [ \"route\" ]\n         },\n         {\n
+        \           \"long_name\" : \"Downtown\",\n            \"short_name\" : \"Downtown\",\n
+        \           \"types\" : [ \"neighborhood\", \"political\" ]\n         },\n
+        \        {\n            \"long_name\" : \"Victoria\",\n            \"short_name\"
+        : \"Victoria\",\n            \"types\" : [ \"locality\", \"political\" ]\n
+        \        },\n         {\n            \"long_name\" : \"Capital\",\n            \"short_name\"
+        : \"CRD\",\n            \"types\" : [ \"administrative_area_level_2\", \"political\"
+        ]\n         },\n         {\n            \"long_name\" : \"British Columbia\",\n
+        \           \"short_name\" : \"BC\",\n            \"types\" : [ \"administrative_area_level_1\",
+        \"political\" ]\n         },\n         {\n            \"long_name\" : \"Canada\",\n
+        \           \"short_name\" : \"CA\",\n            \"types\" : [ \"country\",
+        \"political\" ]\n         },\n         {\n            \"long_name\" : \"V8W
+        1T8\",\n            \"short_name\" : \"V8W 1T8\",\n            \"types\" :
+        [ \"postal_code\" ]\n         }\n      ],\n      \"adr_address\" : \"\\u003cspan
+        class=\\\"street-address\\\"\\u003e1218 Wharf St\\u003c/span\\u003e, \\u003cspan
+        class=\\\"locality\\\"\\u003eVictoria\\u003c/span\\u003e, \\u003cspan class=\\\"region\\\"\\u003eBC\\u003c/span\\u003e
+        \\u003cspan class=\\\"postal-code\\\"\\u003eV8W 1T8\\u003c/span\\u003e, \\u003cspan
+        class=\\\"country-name\\\"\\u003eCanada\\u003c/span\\u003e\",\n      \"formatted_address\"
+        : \"1218 Wharf St, Victoria, BC V8W 1T8, Canada\",\n      \"formatted_phone_number\"
+        : \"(250) 590-5298\",\n      \"geometry\" : {\n         \"location\" : {\n
+        \           \"lat\" : 48.426445,\n            \"lng\" : -123.370475\n         },\n
+        \        \"viewport\" : {\n            \"northeast\" : {\n               \"lat\"
+        : 48.4278221302915,\n               \"lng\" : -123.3689770197085\n            },\n
+        \           \"southwest\" : {\n               \"lat\" : 48.4251241697085,\n
+        \              \"lng\" : -123.3716749802915\n            }\n         }\n      },\n
+        \     \"icon\" : \"https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png\",\n
+        \     \"id\" : \"60cefdab8e9827bd470184a6d37958a9c796f111\",\n      \"international_phone_number\"
+        : \"+1 250-590-5298\",\n      \"name\" : \"NARU Korean Restaurant\",\n      \"opening_hours\"
+        : {\n         \"open_now\" : true,\n         \"periods\" : [\n            {\n
+        \              \"close\" : {\n                  \"day\" : 1,\n                  \"time\"
+        : \"1600\"\n               },\n               \"open\" : {\n                  \"day\"
+        : 1,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 1,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 1,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 2,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 2,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 2,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 2,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 3,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 3,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 3,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 3,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 4,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 4,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 4,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 4,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 5,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 5,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 5,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 5,\n                  \"time\" : \"1700\"\n
+        \              }\n            },\n            {\n               \"close\"
+        : {\n                  \"day\" : 6,\n                  \"time\" : \"1600\"\n
+        \              },\n               \"open\" : {\n                  \"day\"
+        : 6,\n                  \"time\" : \"1130\"\n               }\n            },\n
+        \           {\n               \"close\" : {\n                  \"day\" : 6,\n
+        \                 \"time\" : \"2130\"\n               },\n               \"open\"
+        : {\n                  \"day\" : 6,\n                  \"time\" : \"1700\"\n
+        \              }\n            }\n         ],\n         \"weekday_text\" :
+        [\n            \"Monday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n            \"Tuesday:
+        11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n            \"Wednesday: 11:30 AM –
+        4:00 PM, 5:00 – 9:30 PM\",\n            \"Thursday: 11:30 AM – 4:00 PM, 5:00
+        – 9:30 PM\",\n            \"Friday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n
+        \           \"Saturday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM\",\n            \"Sunday:
+        Closed\"\n         ]\n      },\n      \"photos\" : [\n         {\n            \"height\"
+        : 3024,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAyipALrR4oACjsWaMTj1KHgmsgHtavtkBW4LlwGHflp3czKxQmN3wgO_biBFc4V03f1_Y4LyUMK6lV8DRHeNsnMLDY697nJUAeqfYXGF34cDyWc4sITfSkWE_-1EyDjvqEhA90UIX6YTFeJkJ6Jn_B1gGGhSoZKEHizNRXRhZSpnlyQOCuXML2g\",\n
+        \           \"width\" : 4032\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAdZxzj21eH7k3SyfQ07ROfSyKn9_nKBNckdyEied3_KDNrnAGtRuBs0Q-l7apUCkuUCcuYT66NxjaAlZ6oSwVbYGgHYie2HiyIWfH83ftBEFNdMpht37CPTrKIR3jvO8nEhCsArINdeXVgvOQHwmu6m_OGhT5aVZtfD8gSTBHG6GjYgFLtYrLuA\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 4032,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/108119494912502779918\\\"\\u003elucy
+        byun\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\" :
+        \"CmRaAAAAZMgCM9LkoDX2tcxPRD770t2misrkw31AQ65VdLfhNFY3fPtis4W_QD46WaAIufpvwWgmpQRoWItr5AJivZ_EUysbWXr2lT02jusHCVsOo3m0_b6l7bob4Dn4--Mar3E1EhCZoelPDSN5LGCP9ShcWvyJGhSB6FHJ_vh8FQ4aQ_pwPj1ndYyYBg\",\n
+        \           \"width\" : 3024\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAPJy7N0mueO2x5awlEjM3VqVLAQS1eM01yOeSek_phIFeZv8ju-jiOZRtGCTT-HwmVNr08SMcuB6zmJcfXNcoAuHAd_Cgf30aRWhezE_OGjP25SxgX-NUzKMuDcUMS-IqEhDeyt7FiBNsPIh1j8uRLcDtGhR7zel3MD_IDCKVGwywoL2-zY0jRA\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAA6qVRwvhSAGw6UwZx7z8K9Gid1aqBiQ8hAg7BTYKKPIZxy6QFAxwVp5oXnjzaYDZqKTuwBSqrZQlr-0IqJEbsuw8KlUkqNGYJ2SHaSGLOy2lchBElJeQv9sV-JRDrCGCcEhBC-3UMWvgixFm6igWZXycaGhSBoY8PG30_GChA22OWQy1ImSdpUg\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 1536,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/103885090727600394266\\\"\\u003eyong
+        wan cho\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRaAAAANqzm51DZ973nNSjZv6pUCLVMeoSQ0DIRsBW6O0pRHgBofxtFT6fn8_uthmml4-zsNVCHGVccPUMAs196RfBMCSse4Y6f8nXkMC7I4sQUCkTFmpYLFBQhNeK9YSL4OEUbEhBTuG68YBG3Q9idLkj1BpmvGhS17CMg_yDruqHYyAhNjKkXXz1HMQ\",\n
+        \           \"width\" : 2048\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAAyvk_8WDcf3QIm7Dm4Z5q_rWuHT3IE_VbPHewJ6Z_Zc1JJ4zr_gBnDNvayVKrZUQL03N5mgn_tV-KEmMAUC8SUYVeClJxsD3zdp8LD4wd9obP0MsNGyY9q2vQ4MVZerSXEhCDYi9Rcg31aNli7ya1nz6cGhSJDCujXDjypHaIT2ZaSRba1X2TwQ\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 4000,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/102767798335640166022\\\"\\u003eNARU
+        Korean Restaurant\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRZAAAArnxU5rNzwcpZPUcQtBAZB08g8Rh6m4OHJXL5wG5egv85uXgK-HSliYBTzMX-xfZlU_s2p_ygWf-NCuzW_MCj_hvYQ8cb7fAL3AWKTzNBcj-6iOR15b6lyypJhwiMS66DEhCCnsgoUwpjZBDgU6UOyZ2gGhTZIjcVeLVIQyDWqT7podqZ1ymsiQ\",\n
+        \           \"width\" : 6000\n         },\n         {\n            \"height\"
+        : 2048,\n            \"html_attributions\" : [\n               \"\\u003ca
+        href=\\\"https://maps.google.com/maps/contrib/103885090727600394266\\\"\\u003eyong
+        wan cho\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\"
+        : \"CmRaAAAAQjL3UPyy2NYrrDyvDYBKNaxWTBBFdotYZuqXl_onz4upHMq4SGXxjsfcIFgDvBWZyBhPsbfdUK-5fLN2M9SR5fg_seZ83HbusBCWStUPZjSkjUfGuqb1XpWf9i2AEg82EhDX9mhbrd8OKr84obN4I-vVGhQytwmBmxzzT0O7qknPm1FUk5tQkg\",\n
+        \           \"width\" : 1536\n         },\n         {\n            \"height\"
+        : 961,\n            \"html_attributions\" : [\n               \"\\u003ca href=\\\"https://maps.google.com/maps/contrib/104570750953545296721\\\"\\u003eKyou
+        Park\\u003c/a\\u003e\"\n            ],\n            \"photo_reference\" :
+        \"CmRaAAAAgySR8FkE4cCOKLJso2e5MA9sjvTIq5xSUC43AZkbPGm77NDrjWVIy86hCTOM8FuJF3PiOQ9k8vUGepvgN8Igztvyl32mbPGkixZRaGjQMvWXB1MS4nmpnDfOEIqk2rMyEhDuCWbz0qVqn1azj8xxO_esGhRrIXzEV4BN1qUdDZpex-Y6DWagJg\",\n
+        \           \"width\" : 961\n         }\n      ],\n      \"place_id\" : \"ChIJsTuRCYV1j1QRXsKUhvyChQQ\",\n
+        \     \"plus_code\" : {\n         \"compound_code\" : \"CJGH+HR Victoria,
+        British Columbia, Canada\",\n         \"global_code\" : \"84WRCJGH+HR\"\n
+        \     },\n      \"rating\" : 4.5,\n      \"reference\" : \"ChIJsTuRCYV1j1QRXsKUhvyChQQ\",\n
+        \     \"reviews\" : [\n         {\n            \"author_name\" : \"Anisa _\",\n
+        \           \"author_url\" : \"https://www.google.com/maps/contrib/112753285667148678497/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh3.ggpht.com/-jZkZHYANdfw/AAAAAAAAAAI/AAAAAAAAAAA/xZfa87Pp_gE/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"3
+        months ago\",\n            \"text\" : \"Got the hot pot and it was amazing!
+        I’ve had much fair share of Korean food and this place was great. Such a good
+        amount of food and super flavourful. Plus I love the set up of the restaurant
+        itself with the high ceilings and big windows. Good service too \U0001F60A\",\n
+        \           \"time\" : 1572541107\n         },\n         {\n            \"author_name\"
+        : \"Sally Lin\",\n            \"author_url\" : \"https://www.google.com/maps/contrib/104366231054072771635/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh3.ggpht.com/-ngv2j3AdLeQ/AAAAAAAAAAI/AAAAAAAAAAA/uKmZT_yweuU/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"3
+        months ago\",\n            \"text\" : \"The hot pot dishes are really good!
+        Friendly service too. Best Korean food I’ve had in Victoria and I’ve tried
+        a few different places. This restaurant is Vancouver-level good and I lived
+        there for 5 years. Really glad Victoria is lucky enough to have Naru join
+        the restaurant scene! \U0001F642\",\n            \"time\" : 1571804196\n         },\n
+        \        {\n            \"author_name\" : \"Monica W\",\n            \"author_url\"
+        : \"https://www.google.com/maps/contrib/112440640190488425281/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh6.ggpht.com/-BTxWIXo2TGo/AAAAAAAAAAI/AAAAAAAAAAA/82bswRXLfUU/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"a
+        month ago\",\n            \"text\" : \"We had an excellent meal as a group
+        of 8. Reasonably priced and great staff.\",\n            \"time\" : 1576445864\n
+        \        },\n         {\n            \"author_name\" : \"Amy L\",\n            \"author_url\"
+        : \"https://www.google.com/maps/contrib/103882966574906704924/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh4.ggpht.com/-DiP0RyXupTA/AAAAAAAAAAI/AAAAAAAAAAA/UyrvAUqIDKI/s128-c0x00000000-cc-rp-mo-ba3/photo.jpg\",\n
+        \           \"rating\" : 4,\n            \"relative_time_description\" : \"2
+        months ago\",\n            \"text\" : \"Possam is a favorite of ours and it
+        was tasty. Can't wait to come back and try so many delicacies.  Very clean,
+        fast and excellent service.\",\n            \"time\" : 1573893212\n         },\n
+        \        {\n            \"author_name\" : \"Sarah Graham\",\n            \"author_url\"
+        : \"https://www.google.com/maps/contrib/100414946235174593274/reviews\",\n
+        \           \"language\" : \"en\",\n            \"profile_photo_url\" : \"https://lh3.ggpht.com/-kIQXPD6XPXE/AAAAAAAAAAI/AAAAAAAAAAA/uhIR_iODSJk/s128-c0x00000000-cc-rp-mo/photo.jpg\",\n
+        \           \"rating\" : 5,\n            \"relative_time_description\" : \"a
+        month ago\",\n            \"text\" : \"Great service and amazingly delicious
+        food! And great atmosphere!\",\n            \"time\" : 1576386722\n         }\n
+        \     ],\n      \"scope\" : \"GOOGLE\",\n      \"types\" : [ \"restaurant\",
+        \"food\", \"point_of_interest\", \"establishment\" ],\n      \"url\" : \"https://maps.google.com/?cid=325810569155494494\",\n
+        \     \"user_ratings_total\" : 80,\n      \"utc_offset\" : -480,\n      \"vicinity\"
+        : \"1218 Wharf Street, Victoria\"\n   },\n   \"status\" : \"OK\"\n}\n"
+    http_version: 
+  recorded_at: Tue, 04 Feb 2020 01:33:10 GMT
+recorded_with: VCR 5.0.0

--- a/spec/lib/commands/details_spec.rb
+++ b/spec/lib/commands/details_spec.rb
@@ -1,0 +1,58 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../lib/commands/details'
+
+RSpec.describe Commands::Details do
+  describe '#response_body' do
+    it 'should return details about the place if there is a single result' do
+      VCR.use_cassette 'details_single', record: :once do
+        command = Commands::Details.new('naru victoria bc')
+
+        expect(command.response_body).to eq <<~MSG.strip
+          NARU Korean Restaurant
+          1218 Wharf St, Victoria, BC V8W 1T8, Canada
+          Phone: (250) 590-5298
+          Rating: 4.5
+          Open now
+          Hours:
+          * Monday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM
+          * Tuesday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM
+          * Wednesday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM
+          * Thursday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM
+          * Friday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM
+          * Saturday: 11:30 AM – 4:00 PM, 5:00 – 9:30 PM
+          * Sunday: Closed
+        MSG
+      end
+    end
+
+    it 'should return a list of at most 10 places if there are multiple results' do
+      VCR.use_cassette 'details_multiple', record: :once do
+        command = Commands::Details.new('korean restaurant, victoria bc')
+
+        expect(command.response_body).to eq <<~MSG.strip
+          (1) NARU Korean Restaurant, Wharf Street, Victoria, BC, Canada
+          (2) Cera Korean Restaurant, Pandora Avenue, Victoria, BC, Canada
+          (3) Han Korean Restaurant, Johnson Street, Victoria, BC, Canada
+          (4) Sura Korean Restaurant, Douglas Street, Victoria, BC, Canada
+          (5) Sumi Korean Restaurant, Victoria Drive, Vancouver, BC, Canada
+        MSG
+      end
+    end
+
+    it 'should return an error message if the place does not exist' do
+      VCR.use_cassette 'details_not_found', record: :once do
+        arg = '00000000000000000000'
+        command = Commands::Details.new(arg)
+        expect(command.response_body).to eq("NO RESULTS FOR \"#{arg}\"")
+      end
+    end
+
+    it 'should return help for a malformed request' do
+      command = Commands::Details.new('')
+      expect(command.response_body).to eq(Commands::Details.help)
+    end
+  end
+end


### PR DESCRIPTION
The command returns the Google Maps details of a place if there is a single result, or a list of the max top 10 results.

Includes:
- Refactoring Google Maps API piece into separate file and class
- Updating Sorbet
- Updating README
- Adding tests and related VCR cassettes

Note: the 'google-maps' gem doesn't expose Google Maps' 'Search Nearby' functionality, only the 'Details' one, so the 'details' command here is a bit rigid as it is not possible to search for a type of place near a specific location (e.g., restaurants near Seattle WA).  I might eventually look into other gems to see if we can find one that exposes 'Search Nearby'.